### PR TITLE
fix: 一条规则多个验证器时验证结果错误

### DIFF
--- a/src/Traits/MultipleRulesTrait.php
+++ b/src/Traits/MultipleRulesTrait.php
@@ -90,8 +90,7 @@ trait MultipleRulesTrait
                 $rules = is_array($rule[0]) ? $rule[0] : array_map('trim', explode('|', $rule[0]));
 
                 foreach ($rules as $aRule) {
-                    $rule = $this->parseRule($aRule, $rule);
-                    yield $field => $rule;
+                    yield $field => $this->parseRule($aRule, $rule);
                 }
             }
         }

--- a/test/FieldValidationTest.php
+++ b/test/FieldValidationTest.php
@@ -77,6 +77,11 @@ class FieldValidationTest extends TestCase
         $this->assertSame('freeTime is required!!!!', $v->getErrors('freeTime')[0]);
 
         $v = FieldValidation::check($this->data, [
+            ['goods.pear', 'required|int|min:30|max:60']
+        ]);
+        $this->assertTrue($v->isOk());
+
+        $v = FieldValidation::check($this->data, [
             ['userId', 'required|int'],
             ['userId', 'min:1'],
         ]);


### PR DESCRIPTION
未修复前
```php
$v = FieldValidation::check([
        'age' => 5,
    ], [
    ['age', 'required|int|min:3|max:120'],
]);
$v->firstError(); // age maximum boundary is 3
```

p.s. 当前 FieldValidation 使用 `each` 验证器会报错，希望作者近期有空能修复下，或者等我这个月项目忙完了再帮忙修复