### PR TITLE
fix each required not work

### DIFF
--- a/src/ValidationTrait.php
+++ b/src/ValidationTrait.php
@@ -568,8 +568,8 @@ trait ValidationTrait
         $result = [];
 
         foreach ($recently as $item) {
-            if (is_array($item) && isset($item[$field])) {
-                $result[] = $item[$field];
+            if (is_array($item)) {
+                $result[] = isset($item[$field]) ? $item[$field] : '';
             }
         }
         return $result;

--- a/test/RuleValidationTest.php
+++ b/test/RuleValidationTest.php
@@ -546,6 +546,20 @@ class RuleValidationTest extends TestCase
         $this->assertFalse($v->isOk());
         $this->assertCount(1, $v->getErrors());
         $this->assertTrue($v->inError('users.*.name'));
+
+        $v = RuleValidation::check([
+            'users' => [
+                ['id' => 34, 'name' => 'tom'],
+                ['name' => 'john'],
+            ]
+        ], [
+            ['users.*.id', 'each', 'required'],
+            ['users.*.id', 'each', 'number', 'min' => 34],
+        ]);
+
+        $this->assertFalse($v->isOk());
+        $this->assertCount(1, $v->getErrors());
+        $this->assertTrue($v->inError('users.*.id'));
     }
 
     public function testMultiLevelData(): void


### PR DESCRIPTION
fix: #21 each required not work

 
问题出在 getByWildcard 获取数据时，如果 isset 返回 false，就直接跳过，这样后面就不会被验证了

本次修复对于 isset 返回 false 的情况下返回 空字符串，但这样在自定义 isEmpty 验证器的情况下可能会导致非预期结果

所以这边提交了 2 个 PR，另一个 PR  #24  支持自定义 isEmpty 验证器对这种情况的检测