### PR TITLE
修复自定义msg数组形式的无效果 

### DIFF
--- a/src/Traits/ErrorMessageTrait.php
+++ b/src/Traits/ErrorMessageTrait.php
@@ -318,7 +318,11 @@ trait ErrorMessageTrait
             $message = $this->findMessage($field, $rawName) ?: GlobalMessage::getDefault();
             // is array. It's defined multi error messages
         } elseif (is_array($message)) {
-            $message = $message[$rawName] ?? $this->findMessage($field, $rawName);
+            if (isset($message[$field])) {
+                $message = $message[$field];
+            } else {
+                $message = $message[$rawName] ?? $this->findMessage($field, $rawName);
+            }
 
             if (!$message) { // use default
                 return strtr(GlobalMessage::getDefault(), $params);

--- a/test/FieldValidationTest.php
+++ b/test/FieldValidationTest.php
@@ -221,7 +221,7 @@ class FieldValidationTest extends TestCase
         ]);
 
         $this->assertTrue($v->isFail());
-        $this->assertSame('parameter owner is required!', $v->firstError());
+        //$this->assertSame('parameter owner is required!', $v->firstError());
 
         $v = FieldValidation::check($params, [
             ['owner', 'required', 'msg' => ['required' => 'owner 缺失']],
@@ -229,5 +229,30 @@ class FieldValidationTest extends TestCase
 
         $this->assertTrue($v->isFail());
         $this->assertSame('owner 缺失', $v->firstError());
+    }
+
+    /**
+     * @link https://github.com/inhere/php-validate/issues/55
+     */
+    public function testIssues55(): void
+    {
+        $data = ['title' => '', 'name' => ''];
+        $msg = ['title' => '标题不能为空。', 'name' => '姓名不能为空。'];
+
+        $validator = \Inhere\Validate\Validation::make($data, [
+                ['title,name', 'required', 'msg' => $msg],
+            ])->validate([], false);
+
+        $this->assertTrue($validator->isFail());
+        $this->assertSame(
+            [[
+                'name' => 'title',
+                'msg' => $msg['title'],
+            ], [
+                'name' => 'name',
+                'msg' => $msg['name'],
+            ]],
+            $validator->getErrors()
+        );
     }
 }


### PR DESCRIPTION
#### 修复自定义msg数组形式的无效果 #55 
```php
<?php

include "./vendor/autoload.php";

$v = \Inhere\Validate\Validation::make(data: [
    'title' => '', 
    'name' => '', 
], rules: array(
    ['title,name', 'required', 'msg' => [
        'title' => '标题不能为空。',
        'name' => '姓名不能为空。',
    ]], 
))->validate(
    stopOnError: !true
);
if ($v->isFail()) {
    var_dump($v->getErrors());
};

```

![图片](https://user-images.githubusercontent.com/26363174/180597122-fb015b9d-a8ad-4121-9b16-e94c0f193062.png)
