### PR TITLE
refactor(validation): 调整验证器参数类型声明以支持null值

### DIFF
--- a/src/Traits/ErrorMessageTrait.php
+++ b/src/Traits/ErrorMessageTrait.php
@@ -304,7 +304,7 @@ trait ErrorMessageTrait
      *
      * @return string
      */
-    public function getMessage(callable|string $validator, string $field, array $args = [], array|string $message = null): string
+    public function getMessage(callable|string $validator, string $field, array $args = [], null|array|string $message = null): string
     {
         $rawName = is_string($validator) ? $validator : 'callback';
         $params  = [

--- a/src/Traits/ScopedValidatorsTrait.php
+++ b/src/Traits/ScopedValidatorsTrait.php
@@ -342,7 +342,7 @@ trait ScopedValidatorsTrait
      *
      * @return bool
      */
-    public function fileValidator(string $field, array|string $suffixes = null): bool
+    public function fileValidator(string $field, null|array|string $suffixes = null): bool
     {
         if (!$file = $this->uploadedFiles[$field] ?? null) {
             return false;
@@ -373,7 +373,7 @@ trait ScopedValidatorsTrait
      *
      * @return bool
      */
-    public function imageValidator(string $field, array|string $suffixes = null): bool
+    public function imageValidator(string $field, null|array|string $suffixes = null): bool
     {
         if (!$file = $this->uploadedFiles[$field] ?? null) {
             return false;
@@ -452,7 +452,7 @@ trait ScopedValidatorsTrait
      *
      * @todo
      */
-    public function mimesValidator(string $field, array|string $types = null): void
+    public function mimesValidator(string $field, null|array|string $types = null): void
     {
     }
 

--- a/src/Validators.php
+++ b/src/Validators.php
@@ -197,7 +197,7 @@ class Validators
      *
      * @return bool
      */
-    public static function float(mixed $val, float|string|int $min = null, string|float|int $max = null, string|int $flags = 0): bool
+    public static function float(mixed $val, null|float|string|int $min = null, null|string|float|int $max = null, string|int $flags = 0): bool
     {
         if (!is_numeric($val)) {
             return false;
@@ -254,7 +254,7 @@ class Validators
      *    // 'default' => 3, // value to return if the filter fails
      * ]
      */
-    public static function integer(mixed $val, int|string $min = null, int|string $max = null, int|string $flags = 0): bool
+    public static function integer(mixed $val, null|int|string $min = null, null|int|string $max = null, int|string $flags = 0): bool
     {
         if (!is_numeric($val)) {
             return false;
@@ -298,7 +298,7 @@ class Validators
      * @return bool
      * @see integer()
      */
-    public static function int(mixed $val, float|int|string $min = null, float|int|string $max = null, string|int $flags = 0): bool
+    public static function int(mixed $val, null|float|int|string $min = null, null|float|int|string $max = null, string|int $flags = 0): bool
     {
         return self::integer($val, $min, $max, $flags);
     }
@@ -313,7 +313,7 @@ class Validators
      *
      * @return bool
      */
-    public static function number(mixed $val, float|int|string $min = null, float|int|string $max = null, string|int $flags = 0): bool
+    public static function number(mixed $val, null|float|int|string $min = null, null|float|int|string $max = null, string|int $flags = 0): bool
     {
         if (!is_numeric($val)) {
             return false;
@@ -335,7 +335,7 @@ class Validators
      * @return bool
      * @see number()
      */
-    public static function num(mixed $val, float|int|string $min = null, float|int|string $max = null, string|int $flags = 0): bool
+    public static function num(mixed $val, null|float|int|string $min = null, null|float|int|string $max = null, string|int $flags = 0): bool
     {
         return self::number($val, $min, $max, $flags);
     }
@@ -349,7 +349,7 @@ class Validators
      *
      * @return bool
      */
-    public static function string(mixed $val, float|int|string $minLen = 0, float|int|string $maxLen = null): bool
+    public static function string(mixed $val, float|int|string $minLen = 0, null|float|int|string $maxLen = null): bool
     {
         if (!is_string($val)) {
             return false;
@@ -564,7 +564,7 @@ class Validators
      *
      * @return bool
      */
-    public static function size(float|array|int|string $val, float|int|string $min = null, float|int|string $max = null): bool
+    public static function size(float|array|int|string $val, null|float|int|string $min = null, null|float|int|string $max = null): bool
     {
         if (!is_numeric($val)) {
             if (is_string($val)) {
@@ -589,7 +589,7 @@ class Validators
      * @return bool
      * @see Validators::size()
      */
-    public static function between(float|array|int|string $val, int|string $min = null, int|string $max = null): bool
+    public static function between(float|array|int|string $val, null|int|string $min = null, null|int|string $max = null): bool
     {
         return self::size($val, $min, $max);
     }
@@ -602,7 +602,7 @@ class Validators
      * @return bool
      * @see Validators::size()
      */
-    public static function range(float|array|int|string $val, int|string $min = null, int|string $max = null): bool
+    public static function range(float|array|int|string $val, null|int|string $min = null, null|int|string $max = null): bool
     {
         return self::size($val, $min, $max);
     }
@@ -616,7 +616,7 @@ class Validators
      *
      * @return bool
      */
-    public static function length(array|string $val, float|int|string $minLen = 0, float|int|string $maxLen = null): bool
+    public static function length(array|string $val, null|float|int|string $minLen = 0, null|float|int|string $maxLen = null): bool
     {
         if (!is_string($val) && !is_array($val)) {
             return false;
@@ -712,7 +712,7 @@ class Validators
      *
      * @return bool
      */
-    public static function regexp(float|int|string $val, string $regexp, $default = null): bool
+    public static function regexp(float|int|string $val, string $regexp, null $default = null): bool
     {
         $options = [
             'regexp' => $regexp
@@ -734,7 +734,7 @@ class Validators
      *
      * @return bool
      */
-    public static function regex(float|int|string $val, string $regexp, $default = null): bool
+    public static function regex(float|int|string $val, string $regexp, null $default = null): bool
     {
         return self::regexp($val, $regexp, $default);
     }

--- a/src/Validators.php
+++ b/src/Validators.php
@@ -708,11 +708,11 @@ class Validators
      *
      * @param string|numeric $val 要验证的数据
      * @param string $regexp 正则表达式 "/^M(.*)/"
-     * @param null $default
+     * @param mixed $default
      *
      * @return bool
      */
-    public static function regexp(float|int|string $val, string $regexp, null $default = null): bool
+    public static function regexp(float|int|string $val, string $regexp, mixed $default = null): bool
     {
         $options = [
             'regexp' => $regexp
@@ -730,11 +730,11 @@ class Validators
      *
      * @param string|numeric $val
      * @param string $regexp
-     * @param null $default
+     * @param mixed $default
      *
      * @return bool
      */
-    public static function regex(float|int|string $val, string $regexp, null $default = null): bool
+    public static function regex(float|int|string $val, string $regexp, mixed $default = null): bool
     {
         return self::regexp($val, $regexp, $default);
     }


### PR DESCRIPTION
- 修改ErrorMessageTrait中的getMessage方法参数类型顺序
- 更新ScopedValidatorsTrait中fileValidator方法的suffixes参数类型
- 更新ScopedValidatorsTrait中imageValidator方法的suffixes参数类型
- 更新ScopedValidatorsTrait中mimesValidator方法的types参数类型
- 调整Validators类中float方法的min和max参数类型顺序
- 调整Validators类中integer方法的min和max参数类型顺序
- 调整Validators类中int方法的min和max参数类型顺序
- 调整Validators类中number方法的min和max参数类型顺序
- 调整Validators类中num方法的min和max参数类型顺序
- 调整Validators类中string方法的maxLen参数类型顺序
- 调整Validators类中size方法的min和max参数类型顺序
- 调整Validators类中between方法的min和max参数类型顺序
- 调整Validators类中range方法的min和max参数类型顺序
- 调整Validators类中length方法的minLen和maxLen参数类型顺序
- 调整Validators类中regexp方法的default参数类型
- 调整Validators类中regex方法的default参数类型

> fix: #66 